### PR TITLE
Add CLI Flag for Whitespace Control

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -17,6 +17,13 @@ const cli = meow(`
 	  $ strip-json-comments input.json > output.json
 `, {
 	importMeta: import.meta,
+	flags: {
+		whitespace: {
+			name: 'whitespace',
+			type: 'boolean',
+			default: true,
+		}
+	}
 });
 
 function init(data) {


### PR DESCRIPTION
Although the documentation specifies `--no-whitespace` as a possible option, this doesn't actually work because the flags are never defined in **cli.js**. Define the `whitespace` flag and default it to `true` so options for the underlying library can be controlled via the CLI.

**WARNING:** This option might not do what you think. See https://github.com/sindresorhus/strip-json-comments/issues/30#issuecomment-1174024970